### PR TITLE
fix: handle non-colors in hex-to-rgb

### DIFF
--- a/projects/material-css-vars/src/lib/_internal-helper.scss
+++ b/projects/material-css-vars/src/lib/_internal-helper.scss
@@ -35,6 +35,9 @@
 }
 
 @function _mat-css-hex-to-rgb($color) {
+  @if ($color == null) {
+    @return null;
+  }
   @return (red($color), green($color), blue($color));
 }
 

--- a/projects/material-css-vars/src/lib/_public-util.scss
+++ b/projects/material-css-vars/src/lib/_public-util.scss
@@ -119,7 +119,10 @@
   $new-map: ();
   @each $var, $defaultVal in $css-var-map {
     @if ($var != 'contrast') {
-      $new-map: map_merge($new-map, (--palette-#{$paletteType}-#{$var}: #{_mat-css-hex-to-rgb($defaultVal)}));
+      $colorVal: _mat-css-hex-to-rgb($defaultVal);
+      @if $colorVal != null {
+        $new-map: map_merge($new-map, (--palette-#{$paletteType}-#{$var}: #{$colorVal}));
+      }
     }
   }
   @include _mat-css-root($new-map);


### PR DESCRIPTION
The mat-palette function returns a palette that includes contrast-contrast: null. This fix ensures that if mat-css-set-palette-defaults is called with a mat-palette, it does not error. It also removes the need to exclude contrast in the set-palette-defaults mixin.

Add this code to styles.scss to see the error before, or everything working after this fix:
```
$palette: mat-palette($mat-grey);
@include mat-css-set-palette-defaults($palette);
```

alternatively, I could change this to exclude `contrast-contrast` in `set-palette-defaults` like how `contrast` is already excluded. That seems pretty specific to my use-case though.

It would also be fair if you said `set-palette-defaults` should only be called with simple palettes (`$mat-grey` before it is passed in to `mat-palette`). We have a use-case where we would like to call this mixin where we only have access to a full `mat-theme` that gets passed in.