### PR TITLE
feat: allow app theme mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ You want to style your angular material dynamically with all the colors in the r
     $mat-css-light-theme-selector: '.isLightTheme';
  
     // init theme
-    @include initMaterialCssVars();
+    @include initMaterialCssVars() {
+      // If your app has any theme mixins, call them here. 
+      // $mat-css-theme gets set to an appropriate value before this content is called.
+      @include app-theme($mat-css-theme);
+    };
     ```
 4. Add to your main module:
 ```typescript
@@ -148,6 +152,10 @@ $mat-css-default-light-theme: map-merge(
 ## IE 11
 This lib won't work  with IE11 but thanks to @Coly010 there is [a workaround for that too](https://github.com/johannesjo/angular-material-css-vars/issues/11#issuecomment-572749449).
 
+## App Theme Mixins
+The `initMaterialCssVars` mixin allows content to be passed into it. This allows you to create app themes that can take advantage of the dynamic theme created inside this mixin. It may be possible to do all theming using the utility mixins outlined above, but in other cases, you may need access to the theme palette, including foreground and background palettes.
+
+See the Material guide on [Theming your custom component](https://material.angular.io/guide/theming-your-components) for more information.
 
 ## Credit...
 ...goes to @zbirizdo [project](https://github.com/zbirizdo/material-css-vars) on which parts of this are based which is in turn supposedly based on [this gist](https://gist.github.com/shprink/c7f333e3ad51830f14a6383f3ab35439).

--- a/projects/material-css-vars/src/lib/_main.scss
+++ b/projects/material-css-vars/src/lib/_main.scss
@@ -26,19 +26,28 @@
     background: $mat-css-palette-background,
     foreground: $mat-css-palette-foreground,
   ));
+  // set global variable so passed-in content can use the theme
+  $mat-css-theme: $theme !global; 
 
   @at-root {
     // NOTE: light theme is the default theme
     @include angular-material-theme($theme);
+    @content;
 
     @if $dark-theme-selector {
+      $mat-css-theme: $dark-theme !global;
       #{$dark-theme-selector} {
         @include angular-material-theme($dark-theme);
+        // add content passed in, which can use the $theme variable to apply the dark theme to 
+        // other theme mixins needed by the app
+        @content; 
       }
     }
   }
 
   @include mat-css-other-overwrites;
+
+  $mat-css-theme: null !global; 
 }
 
 @mixin initMaterialCssVars(
@@ -47,5 +56,7 @@
   $default-theme-text: $mat-css-text
 ) {
   @include initCssVars($default-theme, $default-theme-text);
-  @include initMatTheme($dark-theme-selector);
+  @include initMatTheme($dark-theme-selector) {
+    @content;
+  };
 }

--- a/src/app/_app.theme.scss
+++ b/src/app/_app.theme.scss
@@ -1,0 +1,12 @@
+@mixin app-theme($theme) {
+  // Extract the palettes you need from the theme definition.
+  $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
+
+  // Define any styles affected by the theme.
+  .app-header {
+    // Use mat-color to extract individual colors from a palette.
+    background-color: mat-color($primary);
+    border: medium solid mat-color($accent, A400);
+  }
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,8 +2,7 @@
 <mat-sidenav-container>
 
 
-  <mat-toolbar class="mat-elevation-z5"
-               color="primary">
+  <mat-toolbar class="mat-elevation-z5 app-header">
     <span class="title">Angular Material CSS Vars Demo</span>
   </mat-toolbar>
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,9 @@
 @import '../projects/material-css-vars/src/lib/main';
+@import './app//app.theme';
 
-@include initMaterialCssVars();
+@include initMaterialCssVars() {
+  @include app-theme($mat-css-theme);
+};
 
 @include mat-css-set-palette-defaults($mat-light-blue, 'primary');
 @include mat-css-set-palette-defaults($mat-pink, 'accent');


### PR DESCRIPTION
This may not be necessary for anyone using variables directly or the convenience mixins provided by this library, but it will be helpful for anyone who is still using traditional scss mixins to do theming in their app. It is also the best way for an app theme to access $is-dark or items in the background/foreground palettes.

Closes #26 