### PR TITLE
Added override to show disabled items as faded in light mode.

### DIFF
--- a/projects/material-css-vars/src/lib/_mat-lib-overwrites.scss
+++ b/projects/material-css-vars/src/lib/_mat-lib-overwrites.scss
@@ -47,4 +47,7 @@
   .mat-checkbox .mat-ripple-element {
     background-color: RGB(var(--palette-foreground-base));
   }
+  .mat-option.mat-option-disabled {
+    color: rgba(var(--palette-foreground-hint-text), 0.38);
+  }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -599,6 +599,22 @@
             </mat-card-content>
           </mat-card>
           <!-- /Material Menu-->
+          
+          <!-- Material Select -->
+          <mat-card>
+            <mat-card-content>
+              <h2>Material Select</h2>
+              <mat-form-field>
+                <mat-label>Choose an option</mat-label>
+                <mat-select>
+                  <mat-option value="option1">Option 1</mat-option>
+                  <mat-option value="option2" disabled>Option 2 (disabled)</mat-option>
+                  <mat-option value="option3">Option 3</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </mat-card-content>
+          </mat-card>
+          <!-- /Material Select-->
 
         </mat-tab>
 


### PR DESCRIPTION
I'm not sure why the alpha of the ```hint-text: var(--palette-foreground-hint-text),``` is 1.
It is correctly going to alpha 0.5 white in dark mode.
But it is alpha 1 in light mode when it should be 0.38.
Dark mode will still override this alpha so it doesn't effect dark mode.

If anyone can help me understand the design of foreground and how we are expected to switch between light and dark mode, we can implement this better.