### PR TITLE
enable passing $typography-config to mat-core

### DIFF
--- a/projects/material-css-vars/src/lib/_main.scss
+++ b/projects/material-css-vars/src/lib/_main.scss
@@ -12,8 +12,8 @@
   @include _mat-css-root($default-theme);
 }
 
-@mixin init-mat-theme($dark-theme-selector) {
-  @include mat-core();
+@mixin init-mat-theme($dark-theme-selector, $typography-config: null) {
+  @include mat-core($typography-config);
   
   $primary: mat-palette($mat-css-palette-primary);
   $accent: mat-palette($mat-css-palette-accent);
@@ -53,10 +53,11 @@
 @mixin init-material-css-vars(
   $default-theme: $mat-css-default-light-theme,
   $dark-theme-selector: $mat-css-dark-theme-selector,
-  $default-theme-text: $mat-css-text
+  $default-theme-text: $mat-css-text,
+  $typography-config: null
 ) {
   @include init-css-vars($default-theme, $default-theme-text);
-  @include init-mat-theme($dark-theme-selector) {
+  @include init-mat-theme($dark-theme-selector, $typography-config) {
     @content;
   };
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,7 +1,13 @@
 @import '../projects/material-css-vars/src/lib/main';
-@import './app//app.theme';
+@import './app/app.theme';
 
-@include init-material-css-vars() {
+$custom-typography: mat-typography-config(
+  $font-family: 'Roboto, monospace',
+  $headline: mat-typography-level(32px, 48px, 700),
+  $body-1: mat-typography-level(16px, 24px, 500)
+);
+
+@include init-material-css-vars($typography-config: $custom-typography) {
   @include app-theme($mat-css-theme);
 };
 


### PR DESCRIPTION
This adds the ability to pass a custom $typography-config, but note like #45 to let those scss variables be changed / used by css vars.


Also how to install the packages correctly? with npm it couldn't find the `@ctrl/tinycolor` because its only in the projects/-folder