### PR TITLE
Fixes follow-up issues with Angular 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ No further action is required, just import the `init-material-css-vars` mixin li
 @include init-material-css-vars;
 ```
 
-### Keep on using the legacy components
+### Keep using the legacy components
 
 Please pass the following configuration to the mixin:
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,43 @@ $custom-typography: mat-typography-config(
 };
 ```
 
+## Updating to Angular v15
+Angular Material v15 introduces MDC based components, which is basically a re-write for a lot of the available components. If you want to update to Angular v15, you need to update `angular-material-css-vars` to v4+.
+
+With Angular v15, you can decide whether to keep using the legacy components, or to switch to the MDC based components.
+
+### Switch to MDC based components
+
+No further action is required, just import the `init-material-css-vars` mixin like before:
+
+```scss
+@import "angular-material-css-vars/main";
+
+@include init-material-css-vars;
+```
+
+### Keep on using the legacy components
+
+Please pass the following configuration to the mixin:
+
+```scss
+@import "angular-material-css-vars/main";
+
+@include init-material-css-vars($load-legacy-components: true, $load-mdc-components: false);
+```
+
+### Use legacy and MDC based components in parallel
+
+> Warning: this will increase your bundle size significantly
+
+Please pass the following configuration to the mixin:
+
+```scss
+@import "angular-material-css-vars/main";
+
+@include init-material-css-vars($load-legacy-components: true, $load-mdc-components: true);
+```
+
 ## upgrading to angular v12
 Angular material v12 interoduces some big changes, which leaves you with two options when upgrading to ng12: You can either stay at angular material v11 and angular-material-css-vars v1.2.0 or you can use v2+ which thanks to @pedrojrivera adds full support for the new version.
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ You want to style your angular material dynamically with all the colors in the r
     ```bash
     npm i angular-material-css-vars -S
     ```
-2. If @angular/material is already configured remove `@import '~@angular/material/theming';` from your main stylesheet file if present.
+2. If @angular/material is already configured remove `@import '@angular/material/theming';` from your main stylesheet file if present.
 3. Add this to your main stylesheet instead:
     ```scss
-    @import '~angular-material-css-vars/main';
+    @import 'angular-material-css-vars/main';
  
     // optional
     $mat-css-dark-theme-selector: '.isDarkTheme';
@@ -69,7 +69,7 @@ export class AppModule {
 ## Utility
 There are also several [utility functions and mixins](https://github.com/johannesjo/angular-material-css-vars/blob/master/projects/material-css-vars/src/lib/_public-util.scss).
 ```scss
-@import '~angular-material-css-vars/public-util';
+@import 'angular-material-css-vars/public-util';
 
 .with-color {
   border-color: mat-css-color-primary(300);
@@ -102,7 +102,7 @@ To make those variables take effect with your mixins, you need to make sure that
 // probably best put in a common variables file and imported before the mixins
 $mat-css-dark-theme-selector: '.isDarkThemeCUSTOM';
 
-@import '~angular-material-css-vars/public-util';
+@import 'angular-material-css-vars/public-util';
 
 .my-component {
   @include mat-css-dark-theme {
@@ -118,8 +118,8 @@ A full list of the theme map [can be found here](https://github.com/johannesjo/a
 ### Set default (fallback palettes)
 There are two ways to set the default fallback theme. One is using the `mat-css-palette-defaults` mixin.
 ```scss
-@import '../projects/material-css-vars/src/lib/public-util';
-@import '../projects/material-css-vars/src/lib/main';
+@import 'angular-material-css-vars/public-util';
+@import 'angular-material-css-vars/main';
 
 @include init-material-css-vars();
 
@@ -129,7 +129,7 @@ There are two ways to set the default fallback theme. One is using the `mat-css-
 ```
 The other is to include your own variables for [$mat-css-default-light-theme](https://github.com/johannesjo/angular-material-css-vars/blob/master/projects/material-css-vars/src/lib/_variables.scss).
 ```scss
-@import '../projects/material-css-vars/src/lib/main';
+@import 'angular-material-css-vars/main';
 
 $mat-css-default-light-theme: map-merge(
   // if you don't want to enter ALL the properties

--- a/projects/material-css-vars/package.json
+++ b/projects/material-css-vars/package.json
@@ -25,5 +25,19 @@
   "dependencies": {
     "@ctrl/tinycolor": "^3.4.0",
     "tslib": "^2.3.0"
+  },
+  "exports": {
+    ".": {
+      "sass": "./src/lib/_main.scss"
+    },
+    "./main": {
+      "sass": "./src/lib/_main.scss"
+    },
+    "./public-util": {
+      "sass": "./src/lib/_public-util.scss"
+    },
+    "./variables": {
+      "sass": "./src/lib/_variables.scss"
+    }
   }
 }

--- a/projects/material-css-vars/src/lib/_main.scss
+++ b/projects/material-css-vars/src/lib/_main.scss
@@ -13,9 +13,13 @@
   @include _mat-css-root($default-theme);
 }
 
-@mixin init-mat-theme($dark-theme-selector, $typography-config: mat.define-typography-config()) {
-  @include mat.core();
-  @include mat.legacy-core();
+@mixin init-mat-theme($dark-theme-selector, $typography-config: mat.define-typography-config(), $load-mdc-components, $load-legacy-components) {
+  @if $load-mdc-components {
+    @include mat.core();
+  }
+  @if $load-legacy-components {
+    @include mat.legacy-core();
+  }
 
   $primary: mat.define-palette($mat-css-palette-primary);
   $accent: mat.define-palette($mat-css-palette-accent);
@@ -49,15 +53,24 @@
   $mat-css-theme: $theme !global;
 
   // NOTE: light theme is the default theme
-  @include mat.all-component-themes($theme);
-  @include mat.all-legacy-component-themes($theme);
+  @if $load-mdc-components {
+    @include mat.all-component-themes($theme);
+  }
+  @if $load-legacy-components {
+    @include mat.all-legacy-component-themes($theme);
+  }
+
   @content;
 
   @if $dark-theme-selector {
     $mat-css-theme: $dark-theme !global;
     #{$dark-theme-selector} {
-      @include mat.all-component-colors($dark-theme);
-      @include mat.all-legacy-component-colors($dark-theme);
+      @if $load-mdc-components {
+        @include mat.all-component-colors($dark-theme);
+      }
+      @if $load-legacy-components {
+        @include mat.all-legacy-component-colors($dark-theme);
+      }
       // add content passed in, which can use the $theme variable to apply the dark theme to
       // other theme mixins needed by the app
       @content;
@@ -73,7 +86,9 @@
   $default-theme: $mat-css-default-light-theme,
   $dark-theme-selector: $mat-css-dark-theme-selector,
   $default-theme-text: $mat-css-text,
-  $typography-config: mat.define-typography-config()
+  $typography-config: mat.define-typography-config(),
+  $load-mdc-components: true,
+  $load-legacy-components: false,
 ) {
   @include init-css-vars($default-theme, $default-theme-text);
   @include init-mat-theme($dark-theme-selector, $typography-config) {

--- a/projects/material-css-vars/src/lib/_main.scss
+++ b/projects/material-css-vars/src/lib/_main.scss
@@ -91,7 +91,7 @@
   $load-legacy-components: false,
 ) {
   @include init-css-vars($default-theme, $default-theme-text);
-  @include init-mat-theme($dark-theme-selector, $typography-config) {
+  @include init-mat-theme($dark-theme-selector, $typography-config, $load-mdc-components, $load-legacy-components) {
     @content;
   }
 }

--- a/projects/material-css-vars/src/lib/_main.scss
+++ b/projects/material-css-vars/src/lib/_main.scss
@@ -15,6 +15,7 @@
 
 @mixin init-mat-theme($dark-theme-selector, $typography-config: mat.define-typography-config()) {
   @include mat.core();
+  @include mat.legacy-core();
 
   $primary: mat.define-palette($mat-css-palette-primary);
   $accent: mat.define-palette($mat-css-palette-accent);
@@ -49,12 +50,14 @@
 
   // NOTE: light theme is the default theme
   @include mat.all-component-themes($theme);
+  @include mat.all-legacy-component-themes($theme);
   @content;
 
   @if $dark-theme-selector {
     $mat-css-theme: $dark-theme !global;
     #{$dark-theme-selector} {
       @include mat.all-component-colors($dark-theme);
+      @include mat.all-legacy-component-colors($dark-theme);
       // add content passed in, which can use the $theme variable to apply the dark theme to
       // other theme mixins needed by the app
       @content;


### PR DESCRIPTION
# Description

* Fixes a Sass build error related to missing package exports. Updated paths of scss files:
  * `_main.scss` can now be imported via `@import "angular-material-css-vars"` or `@import "angular-material-css-vars/main"`
  * `_public-util.scss` can now be imported via `@import "angular-material-css-vars/public-utils"`
  * `_variables.scss` can now be imported via `@import "angular-material-css-vars/variables"`
* Add support for loading styles of Angular Material Legacy Components

## Issues Resolved

#103 

## Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
