### PR TITLE
Fix typography

### DIFF
--- a/projects/material-css-vars/src/lib/_main.scss
+++ b/projects/material-css-vars/src/lib/_main.scss
@@ -59,6 +59,9 @@
   @if $load-legacy-components {
     @include mat.all-legacy-component-themes($theme);
   }
+  
+  // Fix mat-typography class, see https://github.com/angular/components/issues/26184
+  @include mat.typography-hierarchy($theme);
 
   @content;
 


### PR DESCRIPTION
# Description

Fixes the `mat-typography` CSS class, previously it was not correctly applying the typography config

## Issues Resolved

Closes #111

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
