### PR TITLE
fix: expose src/lib paths for projects using ng-packagr

### DIFF
--- a/projects/material-css-vars/package.json
+++ b/projects/material-css-vars/package.json
@@ -38,6 +38,15 @@
     },
     "./variables": {
       "sass": "./src/lib/_variables.scss"
+    },
+    "./src/lib/main": {
+      "sass": "./src/lib/_main.scss"
+    },
+    "./src/lib/public-util": {
+      "sass": "./src/lib/_public-util.scss"
+    },
+    "./src/lib/variables": {
+      "sass": "./src/lib/_variables.scss"
     }
   }
 }


### PR DESCRIPTION
# Description

Exposes `src/lib` paths in `package.json`, because apparently ng-packagr doesn't fully support `exports` and only works if under the given path there is actually a SCSS file.

## Issues Resolved

Closes #94 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
