### PR TITLE
Respect opacity in color utils

### DIFF
--- a/projects/material-css-vars/src/lib/_public-util.scss
+++ b/projects/material-css-vars/src/lib/_public-util.scss
@@ -29,8 +29,13 @@
     }
   }
 
-  @return map_get($palette_, $hue);
+  $color: map_get($palette_, $hue);
 
+  @if (type-of($opacity) == number) {
+    @return rgba($color, $opacity);
+  } @else {
+    @return rgb($color);
+  }
 }
 
 @function mat-css-color-primary($hue: 500,  $opacity: null) {


### PR DESCRIPTION
# Description

Opacity was not being respected on the `_public-util.scss` `mat-css-color` utils after a certain commit. This PR restores that functionality.

## Issues Resolved

Fixes: https://github.com/johannesjo/angular-material-css-vars/issues/121

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
