### PR TITLE
fix: skip all dark theme styles when dark theme selector is set to false

### DIFF
--- a/projects/material-css-vars/src/lib/_public-util.scss
+++ b/projects/material-css-vars/src/lib/_public-util.scss
@@ -139,8 +139,10 @@
 }
 
 @mixin mat-css-dark-theme-global {
-  #{variables.$dark-theme-selector} & {
-    @content;
+  @if variables.$dark-theme-selector {
+    #{variables.$dark-theme-selector} & {
+      @content;
+    }
   }
 }
 
@@ -155,8 +157,10 @@
   #{variables.$light-theme-selector} & {
     @content;
   }
-  #{variables.$dark-theme-selector} & {
-    @content;
+  @if variables.$dark-theme-selector {
+    #{variables.$dark-theme-selector} & {
+      @content;
+    }
   }
 }
 


### PR DESCRIPTION
# Description

When `$dark-theme-selector` is set to `false`, now all dark theme related styles will be skipped.

## Issues Resolved

Closes #136 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
