### PR TITLE
fix: choose auto contrast color based on calculated contrast

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [json-derulo,johannesjo] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [json-derulo, johannesjo] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username

--- a/projects/material-css-vars/src/lib/material-css-vars.service.spec.ts
+++ b/projects/material-css-vars/src/lib/material-css-vars.service.spec.ts
@@ -4,6 +4,7 @@ import { MaterialCssVarsService } from "./material-css-vars.service";
 import { MATERIAL_CSS_VARS_CFG } from "../mat-css-config-token.const";
 import { Renderer2, RendererStyleFlags2 } from "@angular/core";
 import { MatCssPalettePrefix, MaterialCssVariables } from "./model";
+import { TinyColor } from "@ctrl/tinycolor";
 
 describe("MaterialCssVarsService", () => {
   let service: MaterialCssVarsService;
@@ -189,6 +190,32 @@ describe("MaterialCssVarsService", () => {
       service.setAlternativeColorAlgorithm(true);
 
       expect(service.cfg.isAlternativeColorAlgorithm).toBeTrue();
+    });
+  });
+
+  describe("_getContrastColorVar", () => {
+    it("should return obvious dark contrast color choice", () => {
+      const color = new TinyColor("#111111");
+
+      expect(service["_getContrastColorVar"](color)).toBe(
+        MaterialCssVarsService["LIGHT_TEXT_VAR"],
+      );
+    });
+
+    it("should return obvious light contrast color choice", () => {
+      const color = new TinyColor("#eeeeee");
+
+      expect(service["_getContrastColorVar"](color)).toBe(
+        MaterialCssVarsService["DARK_TEXT_VAR"],
+      );
+    });
+
+    it("should return the best contrast in edge cases", () => {
+      const color = new TinyColor("#f0002f");
+
+      expect(service["_getContrastColorVar"](color)).toBe(
+        MaterialCssVarsService["DARK_TEXT_VAR"],
+      );
     });
   });
 });

--- a/projects/material-css-vars/src/lib/material-css-vars.service.ts
+++ b/projects/material-css-vars/src/lib/material-css-vars.service.ts
@@ -49,6 +49,8 @@ export class MaterialCssVarsService {
   isAutoContrast = false;
   private renderer: Renderer2;
   private ROOT: HTMLElement;
+  private readonly _black = new TinyColor("#000000");
+  private readonly _white = new TinyColor("#ffffff");
 
   constructor(
     rendererFactory: RendererFactory2,
@@ -310,9 +312,7 @@ export class MaterialCssVarsService {
     return this.cfg.sortedHues.map((hue) => {
       const hueVarVal = this._getCssVarValue(`${palettePrefix}${hue}`);
       const c = new TinyColor(`rgb(${hueVarVal})`);
-      const contrastColorVar = c.isDark()
-        ? MaterialCssVarsService.LIGHT_TEXT_VAR
-        : MaterialCssVarsService.DARK_TEXT_VAR;
+      const contrastColorVar = this._getContrastColorVar(c);
       return {
         contrastColorVar,
         hue,
@@ -441,5 +441,21 @@ export class MaterialCssVarsService {
   private getColorObject(value: TinyColor): Color {
     const c = new TinyColor(value);
     return { rgb: c.toRgb(), isLight: c.isLight() };
+  }
+
+  private _getContrastColorVar(color: TinyColor): string {
+    const contrastDark = this._getContrast(color, this._black);
+    const contrastLight = this._getContrast(color, this._white);
+    return contrastLight > contrastDark
+      ? MaterialCssVarsService.LIGHT_TEXT_VAR
+      : MaterialCssVarsService.DARK_TEXT_VAR;
+  }
+
+  private _getContrast(color1: TinyColor, color2: TinyColor): number {
+    const luminance1 = color1.getLuminance();
+    const luminance2 = color2.getLuminance();
+    const brightest = Math.max(luminance1, luminance2);
+    const darkest = Math.min(luminance1, luminance2);
+    return (brightest + 0.05) / (darkest + 0.05);
   }
 }

--- a/projects/material-css-vars/src/test/integration.spec.ts
+++ b/projects/material-css-vars/src/test/integration.spec.ts
@@ -97,7 +97,7 @@ describe("integration", () => {
           fixture.detectChanges();
 
           expect(getButtonComputedStyle(fixture).color).toEqual(
-            "rgb(255, 255, 255)",
+            "rgba(0, 0, 0, 0.87)",
           );
         });
       });


### PR DESCRIPTION
# Description

Updates the auto contrast functionality by calculating the actual contrast agains black and white, and choosing the color with the better contrast.

## Issues Resolved

Partly fixes #143 

## Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
