### PR TITLE
refactor: deprecate src/lib/* SCSS entrypoints

### DIFF
--- a/projects/material-css-vars/package.json
+++ b/projects/material-css-vars/package.json
@@ -47,13 +47,13 @@
       "sass": "./src/lib/_variables.scss"
     },
     "./src/lib/main": {
-      "sass": "./src/lib/_main.scss"
+      "sass": "./src/lib/legacy/main.scss"
     },
     "./src/lib/public-util": {
-      "sass": "./src/lib/_public-util.scss"
+      "sass": "./src/lib/legacy/public-util.scss"
     },
     "./src/lib/variables": {
-      "sass": "./src/lib/_variables.scss"
+      "sass": "./src/lib/legacy/variables.scss"
     }
   }
 }

--- a/projects/material-css-vars/src/lib/legacy/main.scss
+++ b/projects/material-css-vars/src/lib/legacy/main.scss
@@ -1,0 +1,3 @@
+@forward "../main";
+
+@warn 'The "angular-material-css-vars/src/lib/main" entrypoint is deprecated. Please use the mixins from the "angular-material-css-vars" entrypoint instead.';

--- a/projects/material-css-vars/src/lib/legacy/public-color-util.scss
+++ b/projects/material-css-vars/src/lib/legacy/public-color-util.scss
@@ -1,0 +1,3 @@
+@forward "../public-color-util";
+
+@warn 'The "angular-material-css-vars/src/lib/public-color-util" entrypoint is deprecated. Please use the utils from the "angular-material-css-vars" entrypoint instead.';

--- a/projects/material-css-vars/src/lib/legacy/public-util.scss
+++ b/projects/material-css-vars/src/lib/legacy/public-util.scss
@@ -1,0 +1,3 @@
+@forward "../public-util";
+
+@warn 'The "angular-material-css-vars/src/lib/public-util" entrypoint is deprecated. Please use the utils from the "angular-material-css-vars" entrypoint instead.';

--- a/projects/material-css-vars/src/lib/legacy/variables.scss
+++ b/projects/material-css-vars/src/lib/legacy/variables.scss
@@ -1,0 +1,3 @@
+@forward "../variables";
+
+@warn 'The "angular-material-css-vars/src/lib/variables" entrypoint is deprecated. Please use the variables from the "angular-material-css-vars" entrypoint instead.';


### PR DESCRIPTION
# Description

Deprecates the `src/lib/*` SCSS entrypoints. With the new single entrypoint it should not be necessary anymore to use them in any case.

## Issues Resolved

n/a

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
