### PR TITLE
fix: ensure correct checkbox check mark color

### DIFF
--- a/projects/material-css-vars/src/lib/_mat-lib-overwrites.scss
+++ b/projects/material-css-vars/src/lib/_mat-lib-overwrites.scss
@@ -169,14 +169,17 @@
   $color-warn: public-util.mat-css-color(500, null, "warn", true);
 
   .mat-mdc-checkbox {
-    &.mat-primary {
-      --mdc-checkbox-selected-checkmark-color: #{$color-primary};
-    }
-    &.mat-accent {
-      --mdc-checkbox-selected-checkmark-color: #{$color-accent};
-    }
-    &.mat-warn {
-      --mdc-checkbox-selected-checkmark-color: #{$color-warn};
+    &,
+    #{variables.$dark-theme-selector} & {
+      &.mat-primary {
+        --mdc-checkbox-selected-checkmark-color: #{$color-primary};
+      }
+      &.mat-accent {
+        --mdc-checkbox-selected-checkmark-color: #{$color-accent};
+      }
+      &.mat-warn {
+        --mdc-checkbox-selected-checkmark-color: #{$color-warn};
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

Ensures that the checkbox check mark color is the contrast color of the used checkbox background color

## Issues Resolved

Closes #147 

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
