### PR TITLE
refactor: simplify provider setup

### DIFF
--- a/projects/material-css-vars/src/lib/material-css-vars.module.ts
+++ b/projects/material-css-vars/src/lib/material-css-vars.module.ts
@@ -14,19 +14,16 @@ import { MaterialCssVarsService } from "./material-css-vars.service";
 @NgModule({
   imports: [CommonModule],
 })
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class MaterialCssVarsModule {
   static forRoot(
     config?: Partial<MaterialCssVariablesConfig>,
   ): ModuleWithProviders<MaterialCssVarsModule> {
     return {
       ngModule: MaterialCssVarsModule,
-      providers: [{ provide: MATERIAL_CSS_VARS_CFG, useValue: config }],
+      providers: [provideMaterialCssVars(config)],
     };
   }
-
-  // This is necessary, so the service is constructed, even if the service is never injected
-  // ToDo: change to environment initializer, like in the provideMaterialCssVars() function below
-  constructor(private materialCssVarsService: MaterialCssVarsService) {}
 }
 
 export function provideMaterialCssVars(


### PR DESCRIPTION
# Description

Refactors the `MaterialCssVarsModule` providers to use the `provideMaterialCssVars()` function internally, to simplify the setup.

## Issues Resolved

n/a

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
