### PR TITLE
fix!: remove legacy SCSS entrypoints

### DIFF
--- a/projects/material-css-vars/package.json
+++ b/projects/material-css-vars/package.json
@@ -45,15 +45,6 @@
     },
     "./variables": {
       "sass": "./src/lib/_variables.scss"
-    },
-    "./src/lib/main": {
-      "sass": "./src/lib/legacy/main.scss"
-    },
-    "./src/lib/public-util": {
-      "sass": "./src/lib/legacy/public-util.scss"
-    },
-    "./src/lib/variables": {
-      "sass": "./src/lib/legacy/variables.scss"
     }
   }
 }

--- a/projects/material-css-vars/src/lib/legacy/main.scss
+++ b/projects/material-css-vars/src/lib/legacy/main.scss
@@ -1,3 +1,0 @@
-@forward "../main";
-
-@warn 'The "angular-material-css-vars/src/lib/main" entrypoint is deprecated. Please use the mixins from the "angular-material-css-vars" entrypoint instead.';

--- a/projects/material-css-vars/src/lib/legacy/public-color-util.scss
+++ b/projects/material-css-vars/src/lib/legacy/public-color-util.scss
@@ -1,3 +1,0 @@
-@forward "../public-color-util";
-
-@warn 'The "angular-material-css-vars/src/lib/public-color-util" entrypoint is deprecated. Please use the utils from the "angular-material-css-vars" entrypoint instead.';

--- a/projects/material-css-vars/src/lib/legacy/public-util.scss
+++ b/projects/material-css-vars/src/lib/legacy/public-util.scss
@@ -1,3 +1,0 @@
-@forward "../public-util";
-
-@warn 'The "angular-material-css-vars/src/lib/public-util" entrypoint is deprecated. Please use the utils from the "angular-material-css-vars" entrypoint instead.';

--- a/projects/material-css-vars/src/lib/legacy/variables.scss
+++ b/projects/material-css-vars/src/lib/legacy/variables.scss
@@ -1,3 +1,0 @@
-@forward "../variables";
-
-@warn 'The "angular-material-css-vars/src/lib/variables" entrypoint is deprecated. Please use the variables from the "angular-material-css-vars" entrypoint instead.';


### PR DESCRIPTION
# Description

Removes the legacy SCSS entrypoints (including `src/lib/`) which are deprecated and throwing warnings for a long time already.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
