### PR TITLE
fix: prevent runtime error when providing undefined config

### DIFF
--- a/projects/material-css-vars/src/lib/material-css-vars.service.ts
+++ b/projects/material-css-vars/src/lib/material-css-vars.service.ts
@@ -57,13 +57,13 @@ export class MaterialCssVarsService {
   constructor() {
     this.renderer = inject(RendererFactory2).createRenderer(null, null);
     const cfg = inject(MATERIAL_CSS_VARS_CFG);
-    this.ROOT = this._getRootElement(cfg.rootSelector);
 
     this.cfg = {
       ...DEFAULT_MAT_CSS_CFG,
       ...cfg,
     };
     this.isAutoContrast = this.cfg.isAutoContrast;
+    this.ROOT = this._getRootElement(this.cfg.rootSelector);
 
     if (typeof this.cfg.isDarkTheme === "boolean") {
       this.setDarkTheme(this.cfg.isDarkTheme);

--- a/projects/material-css-vars/src/mat-css-config-token.const.ts
+++ b/projects/material-css-vars/src/mat-css-config-token.const.ts
@@ -1,5 +1,6 @@
 import { InjectionToken } from "@angular/core";
 import { MaterialCssVariablesConfig } from "./lib/model";
 
-export const MATERIAL_CSS_VARS_CFG =
-  new InjectionToken<MaterialCssVariablesConfig>("Mat Css Config");
+export const MATERIAL_CSS_VARS_CFG = new InjectionToken<
+  MaterialCssVariablesConfig | undefined
+>("Mat Css Config");


### PR DESCRIPTION
# Description

Since v9.1.0, when Material Css Vars is provided without a config, a runtime error is thrown when the service is constructed.

## Issues Resolved

n/a

## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
